### PR TITLE
Added include<vector> to fix build in melodic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,4 @@ CMakeLists.txt.user
 .gradle
 .project
 *.iml
-add
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ CMakeLists.txt.user
 .gradle
 .project
 *.iml
+add
+.vscode

--- a/csrc/jvmLauncher/launcher.h
+++ b/csrc/jvmLauncher/launcher.h
@@ -2,7 +2,7 @@
 #define LAUNCHER_H
 #include <jni.h>
 #include <string>
-
+#include <vector>
 
 struct JavaMethod
 {

--- a/csrc/ros_controllers/IHMCWholeRobotControlJavaBridge.h
+++ b/csrc/ros_controllers/IHMCWholeRobotControlJavaBridge.h
@@ -54,9 +54,12 @@ namespace ihmc_ros_control
         bool addForceTorqueSensorToBuffer(std::string forceTorqueSensorName);
 
     protected:
+        // virtual bool initRequest(hardware_interface::RobotHW* robot_hw,
+        //                          ros::NodeHandle& root_nh, ros::NodeHandle& controller_nh,
+        //                          std::set<std::string>& claimed_resources) override;
         virtual bool initRequest(hardware_interface::RobotHW* robot_hw,
                                  ros::NodeHandle& root_nh, ros::NodeHandle& controller_nh,
-                                 std::set<std::string>& claimed_resources) override;
+                                 std::set<std::string>& claimed_resources);
 
 
     private:


### PR DESCRIPTION
Building this package failed due to the addition of override without the function being overridden and non-addition of include<vector> while using vector functions.
